### PR TITLE
Updated /GET events to separate returned events by pending/confirmed

### DIFF
--- a/backend/database/database.js
+++ b/backend/database/database.js
@@ -68,8 +68,31 @@ const addEvent = async (event) => {
 
 const getEvents = async () => {
     try {
-        const events = await Event.find({}, { __v: 0 });
+        const pendingEvents = await Event.find({ pending: true }, { __v: 0 });
+        const confirmedEvents = await Event.find({ pending: false }, { __v: 0 });
+        const events = {
+            pending: pendingEvents,
+            confirmed: confirmedEvents
+        }
         return events
+    } catch (error) {
+        throw new Error(error)
+    }
+}
+
+const getPendingEvents = async () => {
+    try {
+        const pendingEvents = await Event.find({ pending: true }, { __v: 0 });
+        return pendingEvents
+    } catch (error) {
+        throw new Error(error)
+    }
+}
+
+const getConfirmedEvents = async () => {
+    try {
+        const confirmedEvents = await Event.find({ pending: false }, { __v: 0 });
+        return confirmedEvents
     } catch (error) {
         throw new Error(error)
     }
@@ -134,3 +157,5 @@ module.exports.addGroup = addGroup;
 module.exports.getGroups = getGroups;
 module.exports.deleteGroup = deleteGroup;
 module.exports.getUsers = getUsers;
+module.exports.getPendingEvents = getPendingEvents;
+module.exports.getConfirmedEvents = getConfirmedEvents;

--- a/backend/server/index.js
+++ b/backend/server/index.js
@@ -71,6 +71,36 @@ app.get('/events', async (req, res) => {
     }
 });
 
+// Retrieve all pending events
+app.get('/events/pending', async (req, res) => {
+    console.log('getting all pending events...')
+    try {
+        const response = await db.getPendingEvents()
+        if (response) {
+            return res.send(response)
+        } else {
+            return res.status(500).send({ error: 'Unexpected response' })
+        }
+    } catch (error) {
+        return res.status(500).send({ error: error.message })
+    }
+});
+
+// Retrieve all pending events
+app.get('/events/confirmed', async (req, res) => {
+    console.log('getting all confirmed events...')
+    try {
+        const response = await db.getConfirmedEvents()
+        if (response) {
+            return res.send(response)
+        } else {
+            return res.status(500).send({ error: 'Unexpected response' })
+        }
+    } catch (error) {
+        return res.status(500).send({ error: error.message })
+    }
+});
+
 // Delete an event by event id
 app.delete('/event/:id', async (req, res) => {
     console.log('deleting an event...')


### PR DESCRIPTION
PR Summary:
* Updated /GET events to separate returned events by pending/confirmed
* Added two new endpoints specifically for pending and confirmed events (/events/pending and /events/confirmed)
* Updates have been made to Postman